### PR TITLE
Update configuration to be Terraform workspace specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 
 Terraform code to create resources needed to use the
 [AWS VM Import/Export feature](https://docs.aws.amazon.com/vm-import/latest/userguide/what-is-vmimport.html)
-in the Images (Production) and Images (Staging) accounts in the COOL. This
-includes the `vmimport` service role and `Images-VMImportExportAccess` role for
-each account.
+in the Images (Production) account in the COOL. This includes the `vmimport`
+service role and the `Images-VMImportExportAccess` role.
 
 The `vmimport` service role is required by the VM Import/Export feature as
 specified in the
@@ -29,7 +28,7 @@ section of the documentation.
 - Access to all of the Terraform remote states specified in
   [remote_states.tf](remote_states.tf).
 - The following COOL accounts and roles must have been created:
-  - Images (Production and Staging):
+  - Images (Production):
     [`cisagov/cool-accounts/images`](https://github.com/cisagov/cool-accounts/tree/develop/images)
   - Terraform:
     [`cisagov/cool-accounts/terraform`](https://github.com/cisagov/cool-accounts/tree/develop/terraform)
@@ -52,7 +51,6 @@ section of the documentation.
 |------|---------|
 | aws | ~> 3.38 |
 | aws.images\_production | ~> 3.38 |
-| aws.images\_staging | ~> 3.38 |
 | aws.users | ~> 3.38 |
 | terraform | n/a |
 
@@ -67,28 +65,19 @@ section of the documentation.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.vmimport_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.vmimportexportaccess_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.vmimport_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.vmimportexportaccess_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vmimport_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vmimportexportaccess_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.vmimport_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vmimport_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vmimportexportaccess_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vmimportexportaccess_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [terraform_remote_state.assessment_images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.images_production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.images_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
@@ -111,9 +100,7 @@ section of the documentation.
 |------|-------------|
 | read\_terraform\_state | The IAM policies and role that allow read-only access to the cool-images-vmimport state in the Terraform state bucket. |
 | vmimport\_role\_production | The ARN for the vmimport service role in the Images (Production) account. |
-| vmimport\_role\_staging | The ARN for the vmimport service role in the Images (Staging) account. |
 | vmimportexportaccess\_role\_production | The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Production) account. |
-| vmimportexportaccess\_role\_staging | The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Staging) account. |
 
 ## Notes ##
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Terraform code to create resources needed to use the
 [AWS VM Import/Export feature](https://docs.aws.amazon.com/vm-import/latest/userguide/what-is-vmimport.html)
-in the Images (Production) account in the COOL. This includes the `vmimport`
-service role and the `Images-VMImportExportAccess` role.
+in the Images account in the COOL. This includes the `vmimport` service role
+and the `Images-VMImportExportAccess` role.
 
 The `vmimport` service role is required by the VM Import/Export feature as
 specified in the
@@ -28,7 +28,7 @@ section of the documentation.
 - Access to all of the Terraform remote states specified in
   [remote_states.tf](remote_states.tf).
 - The following COOL accounts and roles must have been created:
-  - Images (Production):
+  - Images:
     [`cisagov/cool-accounts/images`](https://github.com/cisagov/cool-accounts/tree/develop/images)
   - Terraform:
     [`cisagov/cool-accounts/terraform`](https://github.com/cisagov/cool-accounts/tree/develop/terraform)
@@ -50,7 +50,7 @@ section of the documentation.
 | Name | Version |
 |------|---------|
 | aws | ~> 3.38 |
-| aws.images\_production | ~> 3.38 |
+| aws.images | ~> 3.38 |
 | aws.users | ~> 3.38 |
 | terraform | n/a |
 
@@ -64,20 +64,20 @@ section of the documentation.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.vmimportexportaccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.vmimportexportaccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.vmimportexportaccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vmimport_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vmimportexportaccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vmimportexportaccess_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [terraform_remote_state.assessment_images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.images_production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
@@ -99,8 +99,8 @@ section of the documentation.
 | Name | Description |
 |------|-------------|
 | read\_terraform\_state | The IAM policies and role that allow read-only access to the cool-images-vmimport state in the Terraform state bucket. |
-| vmimport\_role\_production | The ARN for the vmimport service role in the Images (Production) account. |
-| vmimportexportaccess\_role\_production | The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Production) account. |
+| vmimport\_role | The ARN for the vmimport service role in the Images account. |
+| vmimportexportaccess\_role | The IAM role that can be assumed to manage VM Import/Export tasks in the Images account. |
 
 ## Notes ##
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,17 +8,7 @@ output "vmimport_role_production" {
   description = "The ARN for the vmimport service role in the Images (Production) account."
 }
 
-output "vmimport_role_staging" {
-  value       = aws_iam_role.vmimport_staging.arn
-  description = "The ARN for the vmimport service role in the Images (Staging) account."
-}
-
 output "vmimportexportaccess_role_production" {
   value       = aws_iam_role.vmimportexportaccess_production
   description = "The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Production) account."
-}
-
-output "vmimportexportaccess_role_staging" {
-  value       = aws_iam_role.vmimportexportaccess_staging
-  description = "The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Staging) account."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,12 +3,12 @@ output "read_terraform_state" {
   description = "The IAM policies and role that allow read-only access to the cool-images-vmimport state in the Terraform state bucket."
 }
 
-output "vmimport_role_production" {
-  value       = aws_iam_role.vmimport_production.arn
-  description = "The ARN for the vmimport service role in the Images (Production) account."
+output "vmimport_role" {
+  value       = aws_iam_role.vmimport.arn
+  description = "The ARN for the vmimport service role in the Images account."
 }
 
-output "vmimportexportaccess_role_production" {
-  value       = aws_iam_role.vmimportexportaccess_production
-  description = "The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Production) account."
+output "vmimportexportaccess_role" {
+  value       = aws_iam_role.vmimportexportaccess
+  description = "The IAM role that can be assumed to manage VM Import/Export tasks in the Images account."
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,11 +7,11 @@ provider "aws" {
 }
 
 # The provider used to create the role that can be assumed to do everything
-# needed in the Images (Production) account.
+# needed in the Images account.
 provider "aws" {
-  alias = "images_production"
+  alias = "images"
   assume_role {
-    role_arn     = data.terraform_remote_state.images_production.outputs.provisionaccount_role.arn
+    role_arn     = data.terraform_remote_state.images.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
   default_tags {

--- a/providers.tf
+++ b/providers.tf
@@ -20,20 +20,6 @@ provider "aws" {
   region = var.aws_region
 }
 
-# The provider used to create the role that can be assumed to do everything
-# needed in the Images (Staging) account.
-provider "aws" {
-  alias = "images_staging"
-  assume_role {
-    role_arn     = data.terraform_remote_state.images_staging.outputs.provisionaccount_role.arn
-    session_name = local.caller_user_name
-  }
-  default_tags {
-    tags = var.tags
-  }
-  region = var.aws_region
-}
-
 # The provider used to create resources inside the Terraform account.
 provider "aws" {
   alias = "terraform"

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -35,21 +35,6 @@ data "terraform_remote_state" "images_production" {
   workspace = "production"
 }
 
-data "terraform_remote_state" "images_staging" {
-  backend = "s3"
-
-  config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
-    dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
-    key            = "cool-accounts/images.tfstate"
-  }
-
-  workspace = "staging"
-}
-
 data "terraform_remote_state" "terraform" {
   backend = "s3"
 

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -16,11 +16,10 @@ data "terraform_remote_state" "assessment_images" {
     key            = "cool-images-assessment-images/terraform.tfstate"
   }
 
-  # There is only one environment for this remote state.
-  workspace = "default"
+  workspace = terraform.workspace
 }
 
-data "terraform_remote_state" "images_production" {
+data "terraform_remote_state" "images" {
   backend = "s3"
 
   config = {
@@ -32,7 +31,7 @@ data "terraform_remote_state" "images_production" {
     key            = "cool-accounts/images.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "terraform" {

--- a/vmimport_policy.tf
+++ b/vmimport_policy.tf
@@ -1,7 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create the IAM policies that give the vmimport service role sufficient
-# permissions to function in the Images (Production) and Images (Staging)
-# accounts.
+# permissions to function in the Images (Production) account.
 # ------------------------------------------------------------------------------
 
 # These policy documents are based on the permissions required for the vmimport
@@ -65,76 +64,10 @@ data "aws_iam_policy_document" "vmimport_production" {
   }
 }
 
-data "aws_iam_policy_document" "vmimport_staging" {
-  # Buckets to use for image import (VM -> AMI)
-  statement {
-    actions = [
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-    ]
-    resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn}/*"
-    ]
-  }
-
-  # Buckets to use for image export (AMI -> VM)
-  statement {
-    actions = [
-      "s3:GetBucketAcl",
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:PutObject",
-    ]
-    resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn}/*"
-    ]
-  }
-
-  # AMI creation
-  statement {
-    actions = [
-      "ec2:CopySnapshot",
-      "ec2:Describe*",
-      "ec2:ModifySnapshotAttribute",
-      "ec2:RegisterImage",
-    ]
-    resources = [
-      "*",
-    ]
-  }
-
-  # Import resources encrypted with an AWS KMS key
-  statement {
-    actions = [
-      "kms:CreateGrant",
-      "kms:Decrypt",
-      "kms:DescribeKey",
-      "kms:Encrypt",
-      "kms:GenerateDataKey*",
-      "kms:ReEncrypt*",
-    ]
-    resources = [
-      "*",
-    ]
-  }
-}
-
 resource "aws_iam_policy" "vmimport_production" {
   provider = aws.images_production
 
   description = var.vmimport_policy_description
   name        = var.vmimport_policy_name
   policy      = data.aws_iam_policy_document.vmimport_production.json
-}
-
-resource "aws_iam_policy" "vmimport_staging" {
-  provider = aws.images_staging
-
-  description = var.vmimport_policy_description
-  name        = var.vmimport_policy_name
-  policy      = data.aws_iam_policy_document.vmimport_staging.json
 }

--- a/vmimport_policy.tf
+++ b/vmimport_policy.tf
@@ -1,12 +1,12 @@
 # ------------------------------------------------------------------------------
-# Create the IAM policies that give the vmimport service role sufficient
-# permissions to function in the Images (Production) account.
+# Create the IAM policy that gives the vmimport service role sufficient
+# permissions to function in the Images account.
 # ------------------------------------------------------------------------------
 
 # These policy documents are based on the permissions required for the vmimport
 # service role as described in
 # https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role
-data "aws_iam_policy_document" "vmimport_production" {
+data "aws_iam_policy_document" "vmimport" {
   # Buckets to use for image import (VM -> AMI)
   statement {
     actions = [
@@ -15,8 +15,8 @@ data "aws_iam_policy_document" "vmimport_production" {
       "s3:ListBucket",
     ]
     resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn}/*"
+      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn,
+      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn}/*"
     ]
   }
 
@@ -30,8 +30,8 @@ data "aws_iam_policy_document" "vmimport_production" {
       "s3:PutObject",
     ]
     resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn}/*"
+      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn,
+      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn}/*"
     ]
   }
 
@@ -64,10 +64,10 @@ data "aws_iam_policy_document" "vmimport_production" {
   }
 }
 
-resource "aws_iam_policy" "vmimport_production" {
-  provider = aws.images_production
+resource "aws_iam_policy" "vmimport" {
+  provider = aws.images
 
   description = var.vmimport_policy_description
   name        = var.vmimport_policy_name
-  policy      = data.aws_iam_policy_document.vmimport_production.json
+  policy      = data.aws_iam_policy_document.vmimport.json
 }

--- a/vmimport_role.tf
+++ b/vmimport_role.tf
@@ -1,20 +1,19 @@
 # ------------------------------------------------------------------------------
-# Create the IAM roles that allow full access to the assessment images
-# bucket in the Images (Production) account.
+# Create the IAM role that allows full access to the assessment images
+# bucket in the Images account.
 # ------------------------------------------------------------------------------
 
-resource "aws_iam_role" "vmimport_production" {
-  provider = aws.images_production
+resource "aws_iam_role" "vmimport" {
+  provider = aws.images
 
   assume_role_policy = data.aws_iam_policy_document.vmimport_assume_role.json
   description        = var.vmimport_role_description
   name               = local.vmimport_role_name
-  tags               = { "Workspace" = "production" }
 }
 
-resource "aws_iam_role_policy_attachment" "vmimport_production" {
-  provider = aws.images_production
+resource "aws_iam_role_policy_attachment" "vmimport" {
+  provider = aws.images
 
-  policy_arn = aws_iam_policy.vmimport_production.arn
-  role       = aws_iam_role.vmimport_production.name
+  policy_arn = aws_iam_policy.vmimport.arn
+  role       = aws_iam_role.vmimport.name
 }

--- a/vmimport_role.tf
+++ b/vmimport_role.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create the IAM roles that allow full access to the assessment images
-# buckets in the Images (Production) and Images (Staging) accounts.
+# bucket in the Images (Production) account.
 # ------------------------------------------------------------------------------
 
 resource "aws_iam_role" "vmimport_production" {
@@ -17,20 +17,4 @@ resource "aws_iam_role_policy_attachment" "vmimport_production" {
 
   policy_arn = aws_iam_policy.vmimport_production.arn
   role       = aws_iam_role.vmimport_production.name
-}
-
-resource "aws_iam_role" "vmimport_staging" {
-  provider = aws.images_staging
-
-  assume_role_policy = data.aws_iam_policy_document.vmimport_assume_role.json
-  description        = var.vmimport_role_description
-  name               = local.vmimport_role_name
-  tags               = { "Workspace" = "staging" }
-}
-
-resource "aws_iam_role_policy_attachment" "vmimport_staging" {
-  provider = aws.images_staging
-
-  policy_arn = aws_iam_policy.vmimport_staging.arn
-  role       = aws_iam_role.vmimport_staging.name
 }

--- a/vmimportexportaccess_policy.tf
+++ b/vmimportexportaccess_policy.tf
@@ -1,14 +1,13 @@
 # ------------------------------------------------------------------------------
 # Create the IAM policies that give sufficient permissions to manage VM
-# Import/Export tasks in the Images (Production) and Images (Staging) accounts
-# using the AWS CLI.
+# Import/Export tasks in the Images (Production) account using the AWS CLI.
 # ------------------------------------------------------------------------------
 
-# These policy documents are based on the permissions required to use the VM
+# This policy document is based on the permissions required to use the VM
 # Import/Export feature as described in
 # https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#iam-permissions-image
 # The CreateBucket and DeleteBucket permissions have been omitted as management
-# of the buckets is handled by the cisagov/cool-images-assessment-images project.
+# of the bucket is handled by the cisagov/cool-images-assessment-images project.
 data "aws_iam_policy_document" "vmimportexportaccess_production" {
   statement {
     actions = [
@@ -68,77 +67,10 @@ data "aws_iam_policy_document" "vmimportexportaccess_production" {
   }
 }
 
-data "aws_iam_policy_document" "vmimportexportaccess_staging" {
-  statement {
-    actions = [
-      "s3:ListAllMyBuckets"
-    ]
-    resources = [
-      "*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "s3:DeleteObject",
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:PutObject",
-    ]
-    resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn}/*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "ec2:CancelConversionTask",
-      "ec2:CancelExportTask",
-      "ec2:CancelImportTask",
-      "ec2:CreateImage",
-      "ec2:CreateInstanceExportTask",
-      "ec2:CreateTags",
-      "ec2:DeleteTags",
-      "ec2:DescribeConversionTasks",
-      "ec2:DescribeExportImageTasks",
-      "ec2:DescribeExportTasks",
-      "ec2:DescribeImages",
-      "ec2:DescribeImportImageTasks",
-      "ec2:DescribeImportSnapshotTasks",
-      "ec2:DescribeInstanceAttribute",
-      "ec2:DescribeInstances",
-      "ec2:DescribeInstanceStatus",
-      "ec2:DescribeSnapshots",
-      "ec2:DescribeTags",
-      "ec2:ExportImage",
-      "ec2:ImportImage",
-      "ec2:ImportInstance",
-      "ec2:ImportSnapshot",
-      "ec2:ImportVolume",
-      "ec2:StartInstances",
-      "ec2:StopInstances",
-      "ec2:TerminateInstances",
-    ]
-    resources = [
-      "*"
-    ]
-  }
-}
-
 resource "aws_iam_policy" "vmimportexportaccess_production" {
   provider = aws.images_production
 
   description = var.vmimportexportaccess_role_description
   name        = var.vmimportexportaccess_role_name
   policy      = data.aws_iam_policy_document.vmimportexportaccess_production.json
-}
-
-resource "aws_iam_policy" "vmimportexportaccess_staging" {
-  provider = aws.images_staging
-
-  description = var.vmimportexportaccess_role_description
-  name        = var.vmimportexportaccess_role_name
-  policy      = data.aws_iam_policy_document.vmimportexportaccess_staging.json
 }

--- a/vmimportexportaccess_policy.tf
+++ b/vmimportexportaccess_policy.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
-# Create the IAM policies that give sufficient permissions to manage VM
-# Import/Export tasks in the Images (Production) account using the AWS CLI.
+# Create the IAM policy that gives sufficient permissions to manage VM
+# Import/Export tasks in the Images account using the AWS CLI.
 # ------------------------------------------------------------------------------
 
 # This policy document is based on the permissions required to use the VM
@@ -8,7 +8,7 @@
 # https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#iam-permissions-image
 # The CreateBucket and DeleteBucket permissions have been omitted as management
 # of the bucket is handled by the cisagov/cool-images-assessment-images project.
-data "aws_iam_policy_document" "vmimportexportaccess_production" {
+data "aws_iam_policy_document" "vmimportexportaccess" {
   statement {
     actions = [
       "s3:ListAllMyBuckets"
@@ -27,8 +27,8 @@ data "aws_iam_policy_document" "vmimportexportaccess_production" {
       "s3:PutObject",
     ]
     resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn}/*"
+      data.terraform_remote_state.assessment_images.outputs.imagesassessment_images_bucket.arn,
+      "${data.terraform_remote_state.assessment_images.outputs.imagesassessment_images_bucket.arn}/*"
     ]
   }
 
@@ -67,10 +67,10 @@ data "aws_iam_policy_document" "vmimportexportaccess_production" {
   }
 }
 
-resource "aws_iam_policy" "vmimportexportaccess_production" {
-  provider = aws.images_production
+resource "aws_iam_policy" "vmimportexportaccess" {
+  provider = aws.images
 
   description = var.vmimportexportaccess_role_description
   name        = var.vmimportexportaccess_role_name
-  policy      = data.aws_iam_policy_document.vmimportexportaccess_production.json
+  policy      = data.aws_iam_policy_document.vmimportexportaccess.json
 }

--- a/vmimportexportaccess_role.tf
+++ b/vmimportexportaccess_role.tf
@@ -1,20 +1,19 @@
 # ------------------------------------------------------------------------------
-# Create the IAM roles that have sufficient permissions to manage VM
-# Import/Export tasks in the Images (Production) account using the AWS CLI.
+# Create the IAM role that has sufficient permissions to manage VM
+# Import/Export tasks in the Images account using the AWS CLI.
 # ------------------------------------------------------------------------------
 
-resource "aws_iam_role" "vmimportexportaccess_production" {
-  provider = aws.images_production
+resource "aws_iam_role" "vmimportexportaccess" {
+  provider = aws.images
 
   assume_role_policy = data.aws_iam_policy_document.vmimportexportaccess_assume_role.json
   description        = var.vmimportexportaccess_role_description
   name               = var.vmimportexportaccess_role_name
-  tags               = { "Workspace" = "production" }
 }
 
-resource "aws_iam_role_policy_attachment" "vmimportexportaccess_production" {
-  provider = aws.images_production
+resource "aws_iam_role_policy_attachment" "vmimportexportaccess" {
+  provider = aws.images
 
-  policy_arn = aws_iam_policy.vmimportexportaccess_production.arn
-  role       = aws_iam_role.vmimportexportaccess_production.name
+  policy_arn = aws_iam_policy.vmimportexportaccess.arn
+  role       = aws_iam_role.vmimportexportaccess.name
 }

--- a/vmimportexportaccess_role.tf
+++ b/vmimportexportaccess_role.tf
@@ -1,7 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create the IAM roles that have sufficient permissions to manage VM
-# Import/Export tasks in the Images (Production) and Images (Staging) accounts
-# using the AWS CLI.
+# Import/Export tasks in the Images (Production) account using the AWS CLI.
 # ------------------------------------------------------------------------------
 
 resource "aws_iam_role" "vmimportexportaccess_production" {
@@ -18,20 +17,4 @@ resource "aws_iam_role_policy_attachment" "vmimportexportaccess_production" {
 
   policy_arn = aws_iam_policy.vmimportexportaccess_production.arn
   role       = aws_iam_role.vmimportexportaccess_production.name
-}
-
-resource "aws_iam_role" "vmimportexportaccess_staging" {
-  provider = aws.images_staging
-
-  assume_role_policy = data.aws_iam_policy_document.vmimportexportaccess_assume_role.json
-  description        = var.vmimportexportaccess_role_description
-  name               = var.vmimportexportaccess_role_name
-  tags               = { "Workspace" = "staging" }
-}
-
-resource "aws_iam_role_policy_attachment" "vmimportexportaccess_staging" {
-  provider = aws.images_staging
-
-  policy_arn = aws_iam_policy.vmimportexportaccess_staging.arn
-  role       = aws_iam_role.vmimportexportaccess_staging.name
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request separates this configuration to be specific to its Terraform workspace instead of explicitly containing configuration for our Production and Staging environments. This closes #10.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When https://github.com/cisagov/cool-images-assessment-images/pull/17 is merged it will no longer provide a monolithic configuration for the buckets that the `vmimport` role(s) need to access. This allows us to break this configuration down to a workspace specific implementation. This also aligns with the goal of completely separating our Production and Staging environments. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
