### PR TITLE
Support new COOL environment structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 [![GitHub Build Status](https://github.com/cisagov/cool-images-vmimport/workflows/build/badge.svg)](https://github.com/cisagov/cool-images-vmimport/actions)
 
-Terraform code to create resources needed to use the
-[AWS VM Import/Export feature](https://docs.aws.amazon.com/vm-import/latest/userguide/what-is-vmimport.html)
-in the Images (Production) and Images (Staging) accounts in the COOL. This
-includes the `vmimport` service role and `Images-VMImportExportAccess` role for
-each account.
+Terraform code to create resources needed to use the [AWS VM Import/Export
+feature](https://docs.aws.amazon.com/vm-import/latest/userguide/what-is-vmimport.html)
+in the Images account in the COOL. This includes the `vmimport` service role and
+`Images-VMImportExportAccess` role for each account.
 
 The `vmimport` service role is required by the VM Import/Export feature as
 specified in the
@@ -29,7 +28,7 @@ section of the documentation.
 - Access to all of the Terraform remote states specified in
   [remote_states.tf](remote_states.tf).
 - The following COOL accounts and roles must have been created:
-  - Images (Production and Staging):
+  - Images:
     [`cisagov/cool-accounts/images`](https://github.com/cisagov/cool-accounts/tree/develop/images)
   - Terraform:
     [`cisagov/cool-accounts/terraform`](https://github.com/cisagov/cool-accounts/tree/develop/terraform)
@@ -52,8 +51,7 @@ section of the documentation.
 | Name | Version |
 |------|---------|
 | aws | ~> 4.9 |
-| aws.images\_production | ~> 4.9 |
-| aws.images\_staging | ~> 4.9 |
+| aws.images | ~> 4.9 |
 | aws.users | ~> 4.9 |
 | terraform | n/a |
 
@@ -67,29 +65,20 @@ section of the documentation.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.vmimport_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.vmimportexportaccess_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.vmimport_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.vmimportexportaccess_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vmimport_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vmimportexportaccess_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.vmimportexportaccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.vmimportexportaccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.vmimportexportaccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vmimport_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vmimport_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vmimport_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vmimportexportaccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vmimportexportaccess_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vmimportexportaccess_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vmimportexportaccess_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [terraform_remote_state.assessment_images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.images_production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.images_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
@@ -100,6 +89,7 @@ section of the documentation.
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
 | read\_terraform\_state\_role\_name | The name to associate with the IAM role and attached policy that allows read-only access to the cool-images-vmimport state in the S3 bucket where Terraform state is stored. | `string` | `"ReadImagesVMImportTerraformState"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
+| terraform\_state\_bucket | The name of the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
 | vmimport\_policy\_description | The description to associate with the IAM policy that allows the permissions necessary for the vmimport service role to allow VM import/export functionality. | `string` | `"Allows permissions necessary for the AWS VM Import/Export feature to function using the specified resources."` | no |
 | vmimport\_policy\_name | The name to associate with the IAM policy that allows the permissions necessary for the vmimport service role to allow VM import/export functionality. | `string` | `"Images-ServiceRoleAccess-vmimport"` | no |
 | vmimport\_role\_description | The description to associate with the vmimport service role. | `string` | `"The service role that is required by the AWS VM Import/Export feature to function in this account."` | no |
@@ -111,10 +101,8 @@ section of the documentation.
 | Name | Description |
 |------|-------------|
 | read\_terraform\_state | The IAM policies and role that allow read-only access to the cool-images-vmimport state in the Terraform state bucket. |
-| vmimport\_role\_production | The ARN for the vmimport service role in the Images (Production) account. |
-| vmimport\_role\_staging | The ARN for the vmimport service role in the Images (Staging) account. |
-| vmimportexportaccess\_role\_production | The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Production) account. |
-| vmimportexportaccess\_role\_staging | The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Staging) account. |
+| vmimport\_role | The ARN for the vmimport service role in the Images account. |
+| vmimportexportaccess\_role | The IAM role that can be assumed to manage VM Import/Export tasks in the Images account. |
 <!-- END_TF_DOCS -->
 
 ## Notes ##

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Terraform code to create resources needed to use the [AWS VM Import/Export
 feature](https://docs.aws.amazon.com/vm-import/latest/userguide/what-is-vmimport.html)
 in the Images account in the COOL. This includes the `vmimport` service role and
-`Images-VMImportExportAccess` role for each account.
+`Images-VMImportExportAccess` role.
 
 The `vmimport` service role is required by the VM Import/Export feature as
 specified in the

--- a/backend.tf
+++ b/backend.tf
@@ -1,10 +1,14 @@
 terraform {
   backend "s3" {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-images-vmimport/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-images-vmimport/terraform.tfstate"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,22 +3,12 @@ output "read_terraform_state" {
   value       = module.read_terraform_state
 }
 
-output "vmimport_role_production" {
-  description = "The ARN for the vmimport service role in the Images (Production) account."
-  value       = aws_iam_role.vmimport_production.arn
+output "vmimport_role" {
+  description = "The ARN for the vmimport service role in the Images account."
+  value       = aws_iam_role.vmimport.arn
 }
 
-output "vmimport_role_staging" {
-  description = "The ARN for the vmimport service role in the Images (Staging) account."
-  value       = aws_iam_role.vmimport_staging.arn
-}
-
-output "vmimportexportaccess_role_production" {
-  description = "The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Production) account."
-  value       = aws_iam_role.vmimportexportaccess_production
-}
-
-output "vmimportexportaccess_role_staging" {
-  description = "The IAM role that can be assumed to manage VM Import/Export tasks in the Images (Staging) account."
-  value       = aws_iam_role.vmimportexportaccess_staging
+output "vmimportexportaccess_role" {
+  description = "The IAM role that can be assumed to manage VM Import/Export tasks in the Images account."
+  value       = aws_iam_role.vmimportexportaccess
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,25 +7,11 @@ provider "aws" {
 }
 
 # The provider used to create the role that can be assumed to do everything
-# needed in the Images (Production) account.
+# needed in the Images account.
 provider "aws" {
-  alias = "images_production"
+  alias = "images"
   assume_role {
-    role_arn     = data.terraform_remote_state.images_production.outputs.provisionaccount_role.arn
-    session_name = local.caller_user_name
-  }
-  default_tags {
-    tags = var.tags
-  }
-  region = var.aws_region
-}
-
-# The provider used to create the role that can be assumed to do everything
-# needed in the Images (Staging) account.
-provider "aws" {
-  alias = "images_staging"
-  assume_role {
-    role_arn     = data.terraform_remote_state.images_staging.outputs.provisionaccount_role.arn
+    role_arn     = data.terraform_remote_state.images.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
   default_tags {
@@ -42,13 +28,7 @@ provider "aws" {
     session_name = local.caller_user_name
   }
   default_tags {
-    # It makes no sense to associate a "Workspace" tag with the
-    # Terraform read role, since it can read the state from any
-    # workspace.
-    #
-    # Such a tag will also flip flop as one switched from staging to
-    # production or vice versa, which is highly annoying.
-    tags = { for k, v in var.tags : k => v if k != "Workspace" }
+    tags = var.tags
   }
   region = var.aws_region
 }

--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -14,6 +14,6 @@ module "read_terraform_state" {
 
   account_ids                 = [local.users_account_id]
   role_name                   = var.read_terraform_state_role_name
-  terraform_state_bucket_name = "cisa-cool-terraform-state"
+  terraform_state_bucket_name = var.terraform_state_bucket
   terraform_state_path        = "cool-images-vmimport/terraform.tfstate"
 }

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -8,78 +8,58 @@ data "terraform_remote_state" "assessment_images" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
+    encrypt        = true
     key            = "cool-images-assessment-images/terraform.tfstate"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
   }
 
-  # There is only one environment for this remote state.
-  workspace = "default"
+  workspace = terraform.workspace
 }
 
-data "terraform_remote_state" "images_production" {
+data "terraform_remote_state" "images" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts/images.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/images.tfstate"
   }
 
-  workspace = "production"
-}
-
-data "terraform_remote_state" "images_staging" {
-  backend = "s3"
-
-  config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
-    dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
-    key            = "cool-accounts/images.tfstate"
-  }
-
-  workspace = "staging"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "terraform" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/terraform.tfstate"
   }
 
-  # There is only one environment for this account, so there is
-  # no need to match the current Terraform workspace.
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "users" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts/users.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/users.tfstate"
   }
 
-  # There is only one environment for this account, so there is
-  # no need to match the current Terraform workspace.
-  workspace = "production"
+  workspace = terraform.workspace
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
+variable "terraform_state_bucket" {
+  description = "The name of the S3 bucket where Terraform state is stored."
+  nullable    = false
+  type        = string
+}
+
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #

--- a/vmimport_policy.tf
+++ b/vmimport_policy.tf
@@ -1,13 +1,12 @@
 # ------------------------------------------------------------------------------
 # Create the IAM policies that give the vmimport service role sufficient
-# permissions to function in the Images (Production) and Images (Staging)
-# accounts.
+# permissions to function in the Images account.
 # ------------------------------------------------------------------------------
 
 # These policy documents are based on the permissions required for the vmimport
 # service role as described in
 # https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role
-data "aws_iam_policy_document" "vmimport_production" {
+data "aws_iam_policy_document" "vmimport" {
   # Buckets to use for image import (VM -> AMI)
   statement {
     actions = [
@@ -16,8 +15,8 @@ data "aws_iam_policy_document" "vmimport_production" {
       "s3:ListBucket",
     ]
     resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn}/*"
+      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn,
+      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn}/*"
     ]
   }
 
@@ -31,8 +30,8 @@ data "aws_iam_policy_document" "vmimport_production" {
       "s3:PutObject",
     ]
     resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn}/*"
+      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn,
+      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn}/*"
     ]
   }
 
@@ -65,76 +64,10 @@ data "aws_iam_policy_document" "vmimport_production" {
   }
 }
 
-data "aws_iam_policy_document" "vmimport_staging" {
-  # Buckets to use for image import (VM -> AMI)
-  statement {
-    actions = [
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-    ]
-    resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn}/*"
-    ]
-  }
-
-  # Buckets to use for image export (AMI -> VM)
-  statement {
-    actions = [
-      "s3:GetBucketAcl",
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:PutObject",
-    ]
-    resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn}/*"
-    ]
-  }
-
-  # AMI creation
-  statement {
-    actions = [
-      "ec2:CopySnapshot",
-      "ec2:Describe*",
-      "ec2:ModifySnapshotAttribute",
-      "ec2:RegisterImage",
-    ]
-    resources = [
-      "*",
-    ]
-  }
-
-  # Import resources encrypted with an AWS KMS key
-  statement {
-    actions = [
-      "kms:CreateGrant",
-      "kms:Decrypt",
-      "kms:DescribeKey",
-      "kms:Encrypt",
-      "kms:GenerateDataKey*",
-      "kms:ReEncrypt*",
-    ]
-    resources = [
-      "*",
-    ]
-  }
-}
-
-resource "aws_iam_policy" "vmimport_production" {
-  provider = aws.images_production
+resource "aws_iam_policy" "vmimport" {
+  provider = aws.images
 
   description = var.vmimport_policy_description
   name        = var.vmimport_policy_name
-  policy      = data.aws_iam_policy_document.vmimport_production.json
-}
-
-resource "aws_iam_policy" "vmimport_staging" {
-  provider = aws.images_staging
-
-  description = var.vmimport_policy_description
-  name        = var.vmimport_policy_name
-  policy      = data.aws_iam_policy_document.vmimport_staging.json
+  policy      = data.aws_iam_policy_document.vmimport.json
 }

--- a/vmimport_role.tf
+++ b/vmimport_role.tf
@@ -1,36 +1,19 @@
 # ------------------------------------------------------------------------------
 # Create the IAM roles that allow full access to the assessment images
-# buckets in the Images (Production) and Images (Staging) accounts.
+# buckets in the Images account.
 # ------------------------------------------------------------------------------
 
-resource "aws_iam_role" "vmimport_production" {
-  provider = aws.images_production
+resource "aws_iam_role" "vmimport" {
+  provider = aws.images
 
   assume_role_policy = data.aws_iam_policy_document.vmimport_assume_role.json
   description        = var.vmimport_role_description
   name               = local.vmimport_role_name
-  tags               = { "Workspace" = "production" }
 }
 
-resource "aws_iam_role_policy_attachment" "vmimport_production" {
-  provider = aws.images_production
+resource "aws_iam_role_policy_attachment" "vmimport" {
+  provider = aws.images
 
-  policy_arn = aws_iam_policy.vmimport_production.arn
-  role       = aws_iam_role.vmimport_production.name
-}
-
-resource "aws_iam_role" "vmimport_staging" {
-  provider = aws.images_staging
-
-  assume_role_policy = data.aws_iam_policy_document.vmimport_assume_role.json
-  description        = var.vmimport_role_description
-  name               = local.vmimport_role_name
-  tags               = { "Workspace" = "staging" }
-}
-
-resource "aws_iam_role_policy_attachment" "vmimport_staging" {
-  provider = aws.images_staging
-
-  policy_arn = aws_iam_policy.vmimport_staging.arn
-  role       = aws_iam_role.vmimport_staging.name
+  policy_arn = aws_iam_policy.vmimport.arn
+  role       = aws_iam_role.vmimport.name
 }

--- a/vmimportexportaccess_policy.tf
+++ b/vmimportexportaccess_policy.tf
@@ -1,7 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create the IAM policies that give sufficient permissions to manage VM
-# Import/Export tasks in the Images (Production) and Images (Staging) accounts
-# using the AWS CLI.
+# Import/Export tasks in the Images account using the AWS CLI.
 # ------------------------------------------------------------------------------
 
 # These policy documents are based on the permissions required to use the VM
@@ -9,7 +8,7 @@
 # https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#iam-permissions-image
 # The CreateBucket and DeleteBucket permissions have been omitted as management
 # of the buckets is handled by the cisagov/cool-images-assessment-images project.
-data "aws_iam_policy_document" "vmimportexportaccess_production" {
+data "aws_iam_policy_document" "vmimportexportaccess" {
   statement {
     actions = [
       "s3:ListAllMyBuckets"
@@ -28,8 +27,8 @@ data "aws_iam_policy_document" "vmimportexportaccess_production" {
       "s3:PutObject",
     ]
     resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_production.arn}/*"
+      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn,
+      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket.arn}/*"
     ]
   }
 
@@ -68,77 +67,10 @@ data "aws_iam_policy_document" "vmimportexportaccess_production" {
   }
 }
 
-data "aws_iam_policy_document" "vmimportexportaccess_staging" {
-  statement {
-    actions = [
-      "s3:ListAllMyBuckets"
-    ]
-    resources = [
-      "*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "s3:DeleteObject",
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:PutObject",
-    ]
-    resources = [
-      data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn,
-      "${data.terraform_remote_state.assessment_images.outputs.assessment_images_bucket_staging.arn}/*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "ec2:CancelConversionTask",
-      "ec2:CancelExportTask",
-      "ec2:CancelImportTask",
-      "ec2:CreateImage",
-      "ec2:CreateInstanceExportTask",
-      "ec2:CreateTags",
-      "ec2:DeleteTags",
-      "ec2:DescribeConversionTasks",
-      "ec2:DescribeExportImageTasks",
-      "ec2:DescribeExportTasks",
-      "ec2:DescribeImages",
-      "ec2:DescribeImportImageTasks",
-      "ec2:DescribeImportSnapshotTasks",
-      "ec2:DescribeInstanceAttribute",
-      "ec2:DescribeInstances",
-      "ec2:DescribeInstanceStatus",
-      "ec2:DescribeSnapshots",
-      "ec2:DescribeTags",
-      "ec2:ExportImage",
-      "ec2:ImportImage",
-      "ec2:ImportInstance",
-      "ec2:ImportSnapshot",
-      "ec2:ImportVolume",
-      "ec2:StartInstances",
-      "ec2:StopInstances",
-      "ec2:TerminateInstances",
-    ]
-    resources = [
-      "*"
-    ]
-  }
-}
-
-resource "aws_iam_policy" "vmimportexportaccess_production" {
-  provider = aws.images_production
+resource "aws_iam_policy" "vmimportexportaccess" {
+  provider = aws.images
 
   description = var.vmimportexportaccess_role_description
   name        = var.vmimportexportaccess_role_name
-  policy      = data.aws_iam_policy_document.vmimportexportaccess_production.json
-}
-
-resource "aws_iam_policy" "vmimportexportaccess_staging" {
-  provider = aws.images_staging
-
-  description = var.vmimportexportaccess_role_description
-  name        = var.vmimportexportaccess_role_name
-  policy      = data.aws_iam_policy_document.vmimportexportaccess_staging.json
+  policy      = data.aws_iam_policy_document.vmimportexportaccess.json
 }

--- a/vmimportexportaccess_role.tf
+++ b/vmimportexportaccess_role.tf
@@ -1,37 +1,19 @@
 # ------------------------------------------------------------------------------
 # Create the IAM roles that have sufficient permissions to manage VM
-# Import/Export tasks in the Images (Production) and Images (Staging) accounts
-# using the AWS CLI.
+# Import/Export tasks in the Images account using the AWS CLI.
 # ------------------------------------------------------------------------------
 
-resource "aws_iam_role" "vmimportexportaccess_production" {
-  provider = aws.images_production
+resource "aws_iam_role" "vmimportexportaccess" {
+  provider = aws.images
 
   assume_role_policy = data.aws_iam_policy_document.vmimportexportaccess_assume_role.json
   description        = var.vmimportexportaccess_role_description
   name               = var.vmimportexportaccess_role_name
-  tags               = { "Workspace" = "production" }
 }
 
-resource "aws_iam_role_policy_attachment" "vmimportexportaccess_production" {
-  provider = aws.images_production
+resource "aws_iam_role_policy_attachment" "vmimportexportaccess" {
+  provider = aws.images
 
-  policy_arn = aws_iam_policy.vmimportexportaccess_production.arn
-  role       = aws_iam_role.vmimportexportaccess_production.name
-}
-
-resource "aws_iam_role" "vmimportexportaccess_staging" {
-  provider = aws.images_staging
-
-  assume_role_policy = data.aws_iam_policy_document.vmimportexportaccess_assume_role.json
-  description        = var.vmimportexportaccess_role_description
-  name               = var.vmimportexportaccess_role_name
-  tags               = { "Workspace" = "staging" }
-}
-
-resource "aws_iam_role_policy_attachment" "vmimportexportaccess_staging" {
-  provider = aws.images_staging
-
-  policy_arn = aws_iam_policy.vmimportexportaccess_staging.arn
-  role       = aws_iam_role.vmimportexportaccess_staging.name
+  policy_arn = aws_iam_policy.vmimportexportaccess.arn
+  role       = aws_iam_role.vmimportexportaccess.name
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes updates in support of the switchover from our legacy account/environment scheme (where staging and production accounts exist within the same AWS organization) to our new scheme (where they do not).

Highlights include:
* Removal of hard-coded references to production and staging resources
* Use of [partial backend configurations](https://developer.hashicorp.com/terraform/language/backend#partial-configuration)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The goal of this PR is to get us closer to our modernized account scheme where there is no more co-mingling of staging and production accounts.  Doing that will result in cleaner code across all COOL-related repositories as well as improved separation of resources across all COOL environments. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this updated Terraform in dev-a, staging-a, and production environments and everything looks as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
